### PR TITLE
Substitui return por raise para tratamento de exceções

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,4 +1,5 @@
 import logging
+import click
 
 logging.basicConfig(
     level=logging.INFO,
@@ -19,7 +20,7 @@ def generate_dates(first_date:str, second_date:str):
         logger.error(
             "The first date must have occurred before the second date."
         )
-        return 
+        raise click.ClickException("Invalid date interval") 
     
     date_list = []
 


### PR DESCRIPTION
Foi observado na issue #8 que, quando o usuário informava uma data inicial maior que a final, o código utilizava `return` para tratar o caso de intervalo de datas inválido. Isso fazia com que a execução continuasse até a `main` e a lib Click exibisse uma traceback completa no terminal, o que não era o comportamento esperado.

Neste PR, a função foi ajustada para substituir o`return` por um `raise click.ClickException("Invalid date interval")`, Dessa forma:

A execução é interrompida imediatamente quando o intervalo de datas é inválido;

O usuário recebe uma mensagem de erro clara;

A saída do terminal fica mais limpa, sem tracebacks desnecessários;

O comportamento da CLI fica alinhado às boas práticas da lib Click.