### PR TITLE
Consumir API para dados do vice-presidente e da primeira-dama

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -33,10 +33,30 @@ def generate_dates(first_date:str, second_date:str):
     logger.info(f"Generated {len(date_list)} dates")
     return date_list
 
-            
 
-
-
+def build_official_url(name,date):
+    if name == "president":
+        return(
+            "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
+            "/agenda-do-presidente-da-republica-lula"
+            f"/agenda-do-presidente-da-republica/json/{date}"
+        )
+    
+    
+    elif name == "vice_president":
+        return(
+            "https://www.gov.br/planalto/pt-br/vice-presidencia"
+            "/agenda-vice-presidente-geraldo-alckmin"
+            f"/agenda-do-vice-presidente-geraldo-alckmin/json/{date}"
+        )
+        
+    elif name == "first_lady":
+        return(
+            "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
+            f"/agenda-da-primeira-dama/agenda-da-primeira-dama/json/{date}"
+        )
+    
+        
 def request_data(url):
     logger.info(f"Requesting {url}")
     import requests
@@ -84,7 +104,6 @@ def get_mongo_client():
         logger.error("Failed to connect to MongoDB. Please try again.")
         return None
         
-
 
 def save_on_file(events):
     from pymongo import MongoClient, errors

--- a/functions.py
+++ b/functions.py
@@ -34,28 +34,29 @@ def generate_dates(first_date:str, second_date:str):
     return date_list
 
 
-def build_official_url(name,date):
-    if name == "president":
-        return(
+def build_official_url(name, date):
+    base_urls = {
+        "president": (
             "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
             "/agenda-do-presidente-da-republica-lula"
-            f"/agenda-do-presidente-da-republica/json/{date}"
-        )
-    
-    
-    elif name == "vice_president":
-        return(
+            "/agenda-do-presidente-da-republica/json/"
+        ),
+        "vice_president": (
             "https://www.gov.br/planalto/pt-br/vice-presidencia"
             "/agenda-vice-presidente-geraldo-alckmin"
-            f"/agenda-do-vice-presidente-geraldo-alckmin/json/{date}"
-        )
-        
-    elif name == "first_lady":
-        return(
+            "/agenda-do-vice-presidente-geraldo-alckmin/json/"
+        ),
+        "first_lady": (
             "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
-            f"/agenda-da-primeira-dama/agenda-da-primeira-dama/json/{date}"
-        )
-    
+            "/agenda-da-primeira-dama/agenda-da-primeira-dama/json/"
+        ),
+    }
+
+    if name not in base_urls:
+        raise ValueError("Invalid official name")
+
+    return f"{base_urls[name]}{date}"
+ 
         
 def request_data(url):
     logger.info(f"Requesting {url}")

--- a/functions.py
+++ b/functions.py
@@ -8,7 +8,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def generate_dates(first_date:str, second_date:str):
+def generate_dates(first_date: str, second_date: str):
     logger.info("Generating dates")
     from datetime import datetime, timedelta
 
@@ -20,34 +20,34 @@ def generate_dates(first_date:str, second_date:str):
         logger.error(
             "The first date must have occurred before the second date."
         )
-        raise click.ClickException("Invalid date interval") 
-    
+        raise click.ClickException("Invalid date interval")
+
     date_list = []
 
     for day in range(day_difference.days):
-        
-        date = (
-            (first_date_parse + timedelta(days=day+1)).strftime("%Y-%m-%d")
-        )
+
+        date = (first_date_parse + timedelta(days=day + 1)).strftime("%Y-%m-%d")
         date_list.append(date)
     logger.info(f"Generated {len(date_list)} dates")
     return date_list
 
 
 def build_official_url(name, date):
+    GOV_AGENDA_BASE_URL = "https://www.gov.br/planalto/pt-br"
+
     base_urls = {
         "president": (
-            "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
+            GOV_AGENDA_BASE_URL + "/acompanhe-o-planalto"
             "/agenda-do-presidente-da-republica-lula"
             "/agenda-do-presidente-da-republica/json/"
         ),
         "vice_president": (
-            "https://www.gov.br/planalto/pt-br/vice-presidencia"
+            GOV_AGENDA_BASE_URL + "/vice-presidencia"
             "/agenda-vice-presidente-geraldo-alckmin"
             "/agenda-do-vice-presidente-geraldo-alckmin/json/"
         ),
         "first_lady": (
-            "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
+            GOV_AGENDA_BASE_URL + "/acompanhe-o-planalto"
             "/agenda-da-primeira-dama/agenda-da-primeira-dama/json/"
         ),
     }
@@ -56,13 +56,13 @@ def build_official_url(name, date):
         raise ValueError("Invalid official name")
 
     return f"{base_urls[name]}{date}"
- 
-        
+
+
 def request_data(url):
     logger.info(f"Requesting {url}")
     import requests
     import json
-    
+
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -79,17 +79,17 @@ def request_data(url):
         "Connection": "keep-alive",
         "Upgrade-Insecure-Requests": "1",
         "Referer": "https://www.google.com/",
-        "Cache-Control": "max-age=0"
+        "Cache-Control": "max-age=0",
     }
 
-    response = requests.get(url, headers= headers)
+    response = requests.get(url, headers=headers)
 
     for day in response.json():
-        if day['isSelected'] == True:
-            events = day['items']
+        if day["isSelected"] == True:
+            events = day["items"]
             logger.info(f"Found {len(events)} events")
             return events
-        
+
 
 def get_mongo_client():
     from pymongo import MongoClient, errors
@@ -104,22 +104,23 @@ def get_mongo_client():
     except errors.ServerSelectionTimeoutError:
         logger.error("Failed to connect to MongoDB. Please try again.")
         return None
-        
+
 
 def save_on_file(events):
     from pymongo import MongoClient, errors
+
     client = get_mongo_client()
 
     if client is None:
         logger.error("We were unable to connect to the database.")
         return
-    
+
     logger.info("Connecting to the database...")
     database = client["GovernmentDB"]
     collection = database["Events"]
     logger.info("Persisting events in the database...")
 
-    try:    
+    try:
         for event in events:
             collection.insert_one(
                 {

--- a/main.py
+++ b/main.py
@@ -1,20 +1,24 @@
 import click
-from functions import generate_dates, request_data, save_on_file
+from functions import (
+    generate_dates,
+    request_data,
+    save_on_file,
+    build_official_url
+) 
 from dotenv import load_dotenv 
 
 load_dotenv()
 @click.command()
+@click.option('--name', prompt='president, vice_president, or first_lady')
 @click.option('--first_date', prompt='start date')
 @click.option('--second_date', prompt='end date')
-def main(first_date, second_date):
+def main(name, first_date, second_date):
     date_list = generate_dates(first_date, second_date)
 
     for date in date_list:
-        url = (
-            "https://www.gov.br/planalto/pt-br/acompanhe-o-planalto"
-            "/agenda-do-presidente-da-republica-lula/agenda-do-presidente-da-republica"
-            f"/json/{date}"
-        )   
+        url = build_official_url(name,date)
+            
+    
         event_list = request_data(url) 
         save_on_file(event_list)
 

--- a/main.py
+++ b/main.py
@@ -4,25 +4,25 @@ from functions import (
     request_data,
     save_on_file,
     build_official_url
-) 
-from dotenv import load_dotenv 
+)
+from dotenv import load_dotenv
 
 load_dotenv()
+
+
 @click.command()
-@click.option('--name', prompt='president, vice_president, or first_lady')
-@click.option('--first_date', prompt='start date')
-@click.option('--second_date', prompt='end date')
+@click.option("--name", prompt="president, vice_president, or first_lady")
+@click.option("--first_date", prompt="start date")
+@click.option("--second_date", prompt="end date")
 def main(name, first_date, second_date):
     date_list = generate_dates(first_date, second_date)
 
     for date in date_list:
-        url = build_official_url(name,date)
-            
-    
-        event_list = request_data(url) 
+        url = build_official_url(name, date)
+
+        event_list = request_data(url)
         save_on_file(event_list)
+
 
 if __name__ == "__main__":
     main()
-
- 


### PR DESCRIPTION
Este PR adiciona a funcionalidade de consumir dados da API para o Vice-Presidente e a Primeira-Dama. Foi criada a função `build_official_url` para gerar URLs específicas para cada cargo, permitindo buscar os eventos de forma individual para o Presidente, Vice-Presidente e Primeira-Dama.

### **Alterações realizadas**

Adicionado suporte para `president`, `vice_president` e` first_lady` na função `build_official_url`.

Atualizado `main.py` para lidar com os novos cargos.

Garantido que a entrada do usuário via CLI aceite os três cargos.

### **Próximos passos**

Atualmente, todos os eventos estão sendo persistidos na mesma collection do MongoDB. Isso será corrigido em uma próxima atualização para armazenar os eventos separadamente por cargo.

Possíveis melhorias adicionais de validação e tratamento de erros serão implementadas futuramente.